### PR TITLE
Found a way to make Beam CLI pip-installable and also run on GCP's Dataflow.

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2020 Alex Rosengarten
+Copyright (c) 2020 Alex Merose
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -3,8 +3,7 @@
 ## Installation
 
 ```shell script
-git clone git@github.com:alxrsngrtn/beam-cli-example.git
-pip install .
+pip install git+https://github.com/alxmrs/beam-cli-example.git#egg=mytool
 ```
 
 ## Usage

--- a/mytool/boom
+++ b/mytool/boom
@@ -1,28 +1,30 @@
 #!/usr/bin/env python3
 
-import tempfile
 import glob
-import os
-import sys
-import mytool
-from mytool.subtool import cli
-from apache_beam.utils import processes
-
 import logging
+import os
+import subprocess
+import sys
+import tempfile
 
+import mytool
 
 if __name__ == '__main__':
-
     logging.getLogger().setLevel(logging.INFO)
 
     with tempfile.TemporaryDirectory() as tmpdir:
         site_pkg = mytool.__path__[0]
-        processes.check_output(
+
+        # Install the subpackage.
+        subprocess.check_call(f'{sys.executable} -m pip install {site_pkg}'.split())
+
+        from subtool import cli
+
+        # Convert subpackage to a tarball
+        subprocess.check_call(
             f'{sys.executable} {site_pkg}/setup.py sdist --dist-dir {tmpdir}'.split(),
-            stderr=processes.STDOUT
         )
 
+        # Set tarball as extra packages for Beam.
         dist_files = glob.glob(os.path.join(tmpdir, '*.tar.gz'))
-
         cli(['--extra_package', dist_files[0]])
-

--- a/mytool/boom
+++ b/mytool/boom
@@ -4,6 +4,7 @@ import tempfile
 import glob
 import os
 import sys
+import mytool
 from mytool.subtool import cli
 from apache_beam.utils import processes
 
@@ -15,8 +16,9 @@ if __name__ == '__main__':
     logging.getLogger().setLevel(logging.INFO)
 
     with tempfile.TemporaryDirectory() as tmpdir:
+        site_pkg = mytool.__path__[0]
         processes.check_output(
-            f'{sys.executable} ./setup.py sdist --dist-dir {tmpdir}'.split(),
+            f'{sys.executable} {site_pkg}/setup.py sdist --dist-dir {tmpdir}'.split(),
             stderr=processes.STDOUT
         )
 

--- a/mytool/boom
+++ b/mytool/boom
@@ -1,6 +1,26 @@
 #!/usr/bin/env python3
 
+import tempfile
+import glob
+import os
+import sys
 from mytool.subtool import cli
+from apache_beam.utils import processes
+
+import logging
+
 
 if __name__ == '__main__':
-    cli(['--setup_file', './setup.py'])
+
+    logging.getLogger().setLevel(logging.INFO)
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        processes.check_output(
+            f'{sys.executable} ./setup.py sdist --dist-dir {tmpdir}'.split(),
+            stderr=processes.STDOUT
+        )
+
+        dist_files = glob.glob(os.path.join(tmpdir, '*.tar.gz'))
+
+        cli(['--extra_package', dist_files[0]])
+

--- a/mytool/setup.py
+++ b/mytool/setup.py
@@ -4,8 +4,8 @@ from setuptools import setup
 setup(
     name='subtool',
     packages=['subtool'],
-    author='Alex Rosengarten',
-    author_email='alxrsngrtn@google.com',
-    url='https://github.com/alxrsngrtn/beam-cli-example',
+    author='Alex Merose',
+    author_email='alxr@google.com',
+    url='https://github.com/alxmrs/beam-cli-example',
     description='A toy python project to demo packaging a dataflow pipeline in a CLI.',
 )

--- a/mytool/setup.py
+++ b/mytool/setup.py
@@ -1,9 +1,9 @@
-from setuptools import setup
+from setuptools import setup, find_packages
 
 
 setup(
     name='subtool',
-    packages=['subtool'],
+    packages=find_packages(),
     author='Alex Merose',
     author_email='alxr@google.com',
     url='https://github.com/alxmrs/beam-cli-example',

--- a/mytool/subtool/main.py
+++ b/mytool/subtool/main.py
@@ -20,7 +20,8 @@ def run(argv: t.List[str]):
     with beam.Pipeline(options=pipeline_opts) as p:
         (
             p
-            | 'Create' >> beam.Create(list(itertools.product(known_args.keyword, repeat=2)))
+            | 'Create' >> beam.Create([known_args.keyword])
+            | 'Expand' >> beam.FlatMap(lambda kw: itertools.product(kw, repeat=2))
             | 'Process' >> beam.MapTuple(pass_through)
-            | 'Print' >> beam.Map(print)
+            | 'Print' >> beam.MapTuple(print)
         )

--- a/setup.py
+++ b/setup.py
@@ -4,9 +4,9 @@ from setuptools import setup, find_packages
 setup(
     name='mytool',
     packages=find_packages(),
-    author='Alex Rosengarten',
-    author_email='alxrsngrtn@google.com',
-    url='https://github.com/alxrsngrtn/beam-cli-example',
+    author='Alex Merose',
+    author_email='alxr@google.com',
+    url='https://github.com/alxmrs/beam-cli-example',
     description='A toy python project to demo packaging a dataflow pipeline in a CLI.',
     install_requirements=['apache-beam[gcp]'],
     scripts=['mytool/boom']


### PR DESCRIPTION
Solution now uses the `--extra_package` method from [the Beam docs](https://beam.apache.org/documentation/sdks/python-pipeline-dependencies/#local-or-nonpypi) to run on Dataflow from pip.

The `boom` script will now install the subpackage (i.e. `subtool`) and convert it to a tarball (via `setup.py sdist`) and pass that archive to the rest of the Beam pipeline. 