### PR TITLE
Small refactor to make subsequent uses a bit faster.

### DIFF
--- a/mytool/boom
+++ b/mytool/boom
@@ -12,14 +12,17 @@ import mytool
 if __name__ == '__main__':
     logging.getLogger().setLevel(logging.INFO)
 
-    with tempfile.TemporaryDirectory() as tmpdir:
-        site_pkg = mytool.__path__[0]
+    site_pkg = mytool.__path__[0]
 
+    try:
+        from subtool import cli
+    except ImportError:
         # Install the subpackage.
         subprocess.check_call(f'{sys.executable} -m pip install {site_pkg}'.split())
 
         from subtool import cli
 
+    with tempfile.TemporaryDirectory() as tmpdir:
         # Convert subpackage to a tarball
         subprocess.check_call(
             f'{sys.executable} {site_pkg}/setup.py sdist --dist-dir {tmpdir}'.split(),


### PR DESCRIPTION
Now, the tool will only attempt a pip-install if it cannot import the subtool.