### PR TITLE
Changing directory before performing sdist

### DIFF
--- a/mytool/boom
+++ b/mytool/boom
@@ -6,6 +6,7 @@ import os
 import subprocess
 import sys
 import tempfile
+import tarfile
 
 import mytool
 
@@ -24,10 +25,16 @@ if __name__ == '__main__':
 
     with tempfile.TemporaryDirectory() as tmpdir:
         # Convert subpackage to a tarball
+        os.chdir(site_pkg)
         subprocess.check_call(
-            f'{sys.executable} {site_pkg}/setup.py sdist --dist-dir {tmpdir}'.split(),
+            f'{sys.executable} ./setup.py sdist --dist-dir {tmpdir}'.split(),
         )
 
         # Set tarball as extra packages for Beam.
-        dist_files = glob.glob(os.path.join(tmpdir, '*.tar.gz'))
-        cli(['--extra_package', dist_files[0]])
+        pkg_archive = glob.glob(os.path.join(tmpdir, '*.tar.gz'))[0]
+
+        with tarfile.open(pkg_archive, 'r') as tar:
+            py_files_in_tar = [f for f in tar.getnames() if f.endswith('.py')]
+            assert len(py_files_in_tar) > 0, 'extra_package must include python files!'
+
+        cli(['--extra_package', pkg_archive])


### PR DESCRIPTION
Also, assert that package archive actually contains python files.

<details>
<summary>(Logs of Dataflow worker successfully installing the subtool.)</summary>

```
"Processing /var/opt/google/dataflow/subtool-0.0.0.tar.gz"
"Building wheels for collected packages: subtool"
" Building wheel for subtool (setup.py): started"
" Building wheel for subtool (setup.py): finished with status 'done'"
" Created wheel for subtool: filename=subtool-0.0.0-py3-none-any.whl size=2093 sha256=ee57432070d875d4ab939060d27abe0253bfb7d34e08f747763bd56eee637da3"
" Stored in directory: /root/.cache/pip/wheels/bf/37/4a/cb50a33540f133c80f2073ee21ba5307cdb6f2e04f2162e06b"
"Successfully built subtool"
"Installing collected packages: subtool"
" Attempting uninstall: subtool"
" Found existing installation: subtool 0.0.0"
" Uninstalling subtool-0.0.0:"
" Successfully uninstalled subtool-0.0.0"
"Successfully installed subtool-0.0.0"
```
</details>